### PR TITLE
Add functional testing to the CI, Add basic selenium tests for the Activity List

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  Package_and_Test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -19,7 +19,51 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+
     - name: Build with Maven
       run: mvn -B package --file pom.xml
       env:
         FALCON_JDBC_URL: ${{ secrets.FALCON_JDBC_URL }}
+
+    - name: Upload packaged jar
+      uses: actions/upload-artifact@v2
+      with:
+        name: project.jar
+        path: target/*.jar
+        
+  Run_Functional_Tests:
+    runs-on: ubuntu-latest
+    needs: Package_and_Test
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Install Google Chrome
+      run: |
+        chmod +x ./scripts/installChrome.sh
+         ./scripts/installChrome.sh
+
+    - name: Download package.jar artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: project.jar
+      
+    - name: Convert the jar to a runnable version
+      run: mv *.jar project.jar
+             
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    
+    - name: Run the Webserver
+      run: java -jar project.jar &
+      env:
+        FALCON_JDBC_URL: ${{ secrets.FALCON_JDBC_URL }}
+    
+    - name: Wait 30 seconds
+      uses: jakejarvis/wait-action@master
+      with:
+        time: '30s'
+     
+    - name: Run Functional tests
+      run: mvn --no-transfer-progress -Dtest=dev.hotdeals.adventurexp.functional_tests.** test

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,19 @@
         	<groupId>org.hibernate</groupId>
         	<artifactId>hibernate-core</artifactId>
         </dependency>
+
+        <!-- Functional testing - Selenium -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>3.141.59</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>4.2.0</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -90,6 +103,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/functional_tests/**</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/scripts/installChrome.sh
+++ b/scripts/installChrome.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+sudo apt install ./google-chrome-stable_current_amd64.deb

--- a/src/test/java/dev/hotdeals/adventurexp/functional_tests/ActivityListTests.java
+++ b/src/test/java/dev/hotdeals/adventurexp/functional_tests/ActivityListTests.java
@@ -1,0 +1,88 @@
+/*
+    Functional frontend tests based of selenium
+    These tests require the main app to be running before they can be run. Therefore, they are excluded from normal testing runs.
+    In order to run them, you must use `mvn -Dtest=dev.hotdeals.adventurexp.functional_tests.** test`
+ */
+
+package dev.hotdeals.adventurexp.functional_tests;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ActivityListTests {
+
+    private static WebDriver webDriver;
+    private final static int port = 8080;
+
+    @BeforeAll
+    public static void setup() {
+        WebDriverManager.chromedriver().setup();
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments("--no-sandbox");
+        options.addArguments("--disable-dev-shm-usage");
+        options.addArguments("--headless");
+        webDriver = new ChromeDriver(options);
+        webDriver.get("http://localhost:" + port);
+        webDriver.manage().window().maximize();
+        webDriver.manage().timeouts().implicitlyWait(20, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void getDefaultTitleTest() {
+        webDriver.get("http://localhost:" + port);
+        assertThat(webDriver.getTitle()).isEqualTo("Activities");
+    }
+
+    @Test
+    public void getIndexTitleTest() {
+        webDriver.get("http://localhost:" + port + "/index");
+        assertThat(webDriver.getTitle()).isEqualTo("Activities");
+    }
+
+    @Test
+    public void getActivitiesTitleTest() {
+        webDriver.get("http://localhost:" + port + "/activities");
+        assertThat(webDriver.getTitle()).isEqualTo("Activities");
+    }
+
+    @Test
+    @DisplayName("Does header image exist")
+    public void DoesHeaderImageExistTest() {
+        webDriver.get("http://localhost:" + port + "/activities");
+        WebElement headerImage = webDriver.findElement(By.id("title-container")).findElement(By.tagName("img"));
+        assertThat(headerImage.isDisplayed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Is header image valid/loaded")
+    public void isHeaderImageValidTest() throws IOException {
+        webDriver.get("http://localhost:" + port + "/activities");
+        WebElement headerImage = webDriver.findElement(By.id("title-container")).findElement(By.tagName("img"));
+        String Source = headerImage.getAttribute("src");
+        BufferedImage img = ImageIO.read(new URL(Source));
+    }
+
+    @AfterAll
+    public static void cleanup() {
+        if (webDriver != null) {
+            webDriver.quit();
+        }
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+    <logger name="org.apache.hc" level="WARN" />
+</configuration>


### PR DESCRIPTION
Add functional testing functionality based off selenium.
Those tests don't trigger when run via mvn test, nor when the project is packaged.
The reason is because they have to be run against a running website.
*none of the tests in the functional_tests package are run*
To run them by hand you can use a command `mvn -Dtest=dev.hotdeals.adventurexp.functional_tests.** test`

I have updated the Continous Integration workflow to reflect this. It now consists of 2 jobs, where the packaged jar that is the result of the first one is uploaded to the second job, and run.
After that the tests within the functional_tests package are run and they will connect to the running app.